### PR TITLE
Add Zenodo metadata for DOI archival

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -10,7 +10,8 @@
     ],
     "contributors": [
         {"type": "Researcher", "name": "Ladislav Bartos", "orcid": "0000-0002-4869-0843"},
-        {"type": "Researcher", "name": "Mikael Lund", "orcid": "0000-0001-8178-8175"}
+        {"type": "Researcher", "name": "Mikael Lund", "orcid": "0000-0001-8178-8175"},
+        {"type": "Researcher", "name": "Semen Yesylevskyy", "orcid": "0000-0002-6748-8931"}
     ],
     "keywords": [
         "molecular dynamics",


### PR DESCRIPTION
The European commission and CERN runs the [Zenodo](https://zenodo.org) archiving service that can connect to and monitor github projects. By providing a Zenodo config file, each new release will be archived and obtain a trackable DOI. For this to work, Marieke would need to activate the repo on Zenodo.org (one can log in with github credentials). I have added orcids - ping also @Ladme for approval.

Example: https://doi.org/10.5281/zenodo.5235137
