### PR TITLE
Python binding XTCReader.frame reference semantics

### DIFF
--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -91,7 +91,7 @@ impl FromPyObject<'_> for AtomSelection {
 #[pyclass]
 struct XTCReader {
     inner: molly::XTCReader<std::fs::File>,
-    frame: Option<Frame>,
+    frame: Option<Py<Frame>>,
     buffered: bool,
 }
 
@@ -121,8 +121,11 @@ impl XTCReader {
     }
 
     #[getter]
-    fn get_frame(&self) -> Option<Frame> {
-        self.frame.clone() // FIXME: Is there a way around this?
+    fn get_frame(&self, py: Python) -> Option<Py<Frame>> {
+        match &self.frame {
+            None => None,
+            Some(frame) => Some(frame.clone_ref(py)),
+        }
     }
 
     /// Returns the offsets of this `XTCReader` from its current position.
@@ -149,20 +152,20 @@ impl XTCReader {
     }
 
     /// Read a single frame into the `frame` field of the `XTCReader`.
-    fn read_frame(&mut self) -> io::Result<()> {
-        if self.frame.is_none() {
-            self.frame = Some(Frame::default());
-        }
-        let frame = &mut self.frame.as_mut().unwrap().inner;
-        self.inner.read_frame(frame)
+    fn read_frame(&mut self, py: Python) -> io::Result<()> {
+        let mut frame = self
+            .frame
+            .get_or_insert(Py::new(py, Frame::default())?)
+            .borrow_mut(py);
+        self.inner.read_frame(&mut frame.inner)
     }
 
     /// Read a single frame and return a copy.
     ///
     /// Calls `read_frame` internally and returns the frame immediately.
-    fn pop_frame(&mut self) -> io::Result<Frame> {
-        self.read_frame()?;
-        Ok(self.frame.clone().unwrap())
+    fn pop_frame(&mut self, py: Python) -> io::Result<Py<Frame>> {
+        self.read_frame(py)?;
+        Ok(self.frame.as_ref().unwrap().clone_ref(py))
     }
 
     /// Read frames according to the selections and return the frames as a list.

--- a/bindings/python/tests/verification.py
+++ b/bindings/python/tests/verification.py
@@ -205,6 +205,25 @@ def test_write_from_scratch():
 
     print(f"\tOK!\t\tWrite from scratch for {n_frames} frames.")
 
+def test_reference_semantics(path):
+    """Tests whether XTCReader's buffered frame has reference semantics."""
+    print("TEST: XTCReader.frame reference semantics")
+    reader = molly.XTCReader(path)
+    # read 1 frame
+    f = reader.pop_frame()
+    assert f.step == 0
+    # read another frame
+    reader.read_frame()
+    # checks whether f is a reference to a single buffered "frame" that
+    # can be mutated by the reader
+    assert f.step > 0
+    # mutate f manually and check if it updated reader.f
+    chosen_number = f.step + 0xabc
+    f.step = chosen_number
+    assert reader.frame.step == chosen_number
+    print(f"\tOK!")
+    print(f"\tXTCReader.frame has reference semantics")
+
 
 path = "../../tests/trajectories/trajectory_smol.xtc"
 full_mda_frames, _ = read_all(path)
@@ -225,3 +244,6 @@ test_write_roundtrip(path)
 
 # Write from scratch test
 test_write_from_scratch()
+
+# XTC Reader frame reference semantics
+test_reference_semantics(path)


### PR DESCRIPTION
This commit changes the semantics of the Python API of XTCReader, in that it moves the ownership of XTCReader.frame from XTCReader to the Python interpreter, using the smart pointer Py<T>. It modifies the functions get_frame(), read_frame() and pop_frame() accordingly. It also adds a test to check reference semantics.

This change resolves a FIXME in XTCReader::get_frame() (line 125), removing the clone every time get_frame() is called.

This change changes the semantics of XTCReader.frame in the Python API. Consider these imaginary examples:

```py
import molly

reader = molly.XTCReader("traj.xtc")
reader.read_frame()
new_positions = some_processing_function(reader.frame.positions)
reader.frame.positions = new_positions.flatten()
```

Previously, this would not actually mutate reader.frame, since each reader.frame invocation would clone the internal Frame object repeatedly. With these changes, this is supported, and will mutate the reader.frame.

Additionally, now read_frame() will mutate existing references to frame.

```py
import molly

reader = molly.XTCReader("traj.xtc")
f = reader.pop_frame()
print(f.step) # Step number of frame 1
reader.read_frame()
print(f.step) # Step number of frame 2
``` 

Note, that there is still cloning involved in the Python API. Consider the following example:

```py
import molly

reader = molly.XTCReader("traj.xtc")
reader.read_frame()
# will not actually edit positions, since the getter for positions clones
reader.frame.positions[0, 0] = 0
```

Though of course, it can be debated what the right semantics are, and whether they make sense from a performance standpoint.

- [x] I've ran bindings/python/tests/verification.py and they pass.