### PR TITLE
Adding write_frame_parts() method to efficiently write coordinates from arbitrary iterator

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -736,8 +736,9 @@ impl<W: Write> XTCWriter<W> {
         Ok(())
     }
 
-    /// Write parts of the frame to XTC file.
-    /// This method allows writing coordinates from any iterator yielding &[f32;3]
+    /// Write parts of the frame to the XTC file.
+    ///
+    /// Coordinates are sourced from any [`ExactSizeIterator`] yielding `&[f32; 3]`.
     pub fn write_frame_parts<'a>(
         &'a mut self,
         step: u32,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -738,10 +738,6 @@ impl<W: Write> XTCWriter<W> {
 
     /// Write parts of the frame to XTC file.
     /// This method allows writing coordinates from any iterator yielding &[f32;3]
-    /// natoms should be provided separately since it has to be known before
-    /// going through iterator.
-    /// # Panics
-    /// Panics if the actual size of iterator is not equal to natoms.
     pub fn write_frame_parts<'a>(
         &'a mut self,
         step: u32,
@@ -751,8 +747,6 @@ impl<W: Write> XTCWriter<W> {
         precision: f32,
     ) -> io::Result<()> {
         let natoms = coords.len();
-        assert_eq!(natoms % 3, 0);
-
         let header = Header {
             magic: self.magic,
             natoms,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ use crate::reader::{
     read_boxvec, read_compressed_positions, read_f32, read_f32s, read_i32, read_u32,
 };
 use crate::selection::{AtomSelection, FrameSelection};
-use crate::writer::write_compressed_positions;
+use crate::writer::{write_compressed_positions, write_int_positions};
 
 pub mod buffer;
 pub mod reader;
@@ -177,7 +177,7 @@ impl Default for Frame {
             time: Default::default(),
             boxvec: Default::default(),
             precision: 1000.,
-            positions: Default::default()
+            positions: Default::default(),
         }
     }
 }
@@ -734,5 +734,51 @@ impl<W: Write> XTCWriter<W> {
             self.file.write_all(&pos.to_be_bytes())?;
         }
         Ok(())
+    }
+
+    /// Write parts of the frame to XTC file.
+    /// This method allows writing coordinates from any iterator yielding &[f32;3]
+    /// natoms should be provided separately since it has to be known before
+    /// going through iterator.
+    /// # Panics
+    /// Panics if the actual size of iterator is not equal to natoms.
+    pub fn write_frame_parts<'a>(
+        &'a mut self,
+        step: u32,
+        time: f32,
+        boxvec: [f32; 9],
+        coords: impl ExactSizeIterator<Item = &'a [f32; 3]>,
+        precision: f32,
+    ) -> io::Result<()> {
+        let natoms = coords.len();
+        assert_eq!(natoms % 3, 0);
+
+        let header = Header {
+            magic: self.magic,
+            natoms,
+            step,
+            time,
+            boxvec,
+            natoms_repeated: natoms,
+        };
+
+        self.file.write_all(&header.to_be_bytes())?;
+
+        if natoms <= 9 {
+            let vec: Vec<f32> = coords.flatten().cloned().collect();
+            assert_eq!(vec.len(), natoms * 3);
+            self.write_smol_positions(&vec)
+        } else {
+            let to_int = |f: f32| (f * precision).round() as i32;
+            let mut int_coords: Vec<[i32; 3]> = coords
+                .map(|p| [to_int(p[0]), to_int(p[1]), to_int(p[2])])
+                .collect();
+            assert_eq!(int_coords.len(), natoms);
+
+            self.file.write_all(&precision.to_be_bytes())?;
+            
+            write_int_positions(&mut self.file, &mut int_coords, self.magic)?;
+            Ok(())
+        }
     }
 }

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -288,6 +288,15 @@ pub fn write_compressed_positions<W: Write>(
         .map(|p| [to_int(p[0]), to_int(p[1]), to_int(p[2])])
         .collect();
 
+    write_int_positions(writer, &mut int_coords, magic)
+}
+
+// Internal function that writes int positions
+pub(crate) fn write_int_positions<W: Write>(
+    writer: &mut W,
+    int_coords: &mut [[i32;3]],
+    magic: Magic,
+) -> io::Result<usize> {
     let (minint, maxint) = calc_bounds(&int_coords);
     let smallidx = find_initial_smallidx(&int_coords);
 
@@ -305,7 +314,7 @@ pub fn write_compressed_positions<W: Write>(
     encode_coordinates(
         &mut compressed,
         &mut state,
-        &mut int_coords,
+        int_coords,
         minint,
         bitsize,
         &sizeint,
@@ -318,6 +327,7 @@ pub fn write_compressed_positions<W: Write>(
 
     Ok(compressed.len())
 }
+
 
 /// Encode coordinates with run-length compression and water swap.
 #[allow(clippy::too_many_arguments)]

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -291,7 +291,6 @@ pub fn write_compressed_positions<W: Write>(
     write_int_positions(writer, &mut int_coords, magic)
 }
 
-// Internal function that writes int positions
 pub(crate) fn write_int_positions<W: Write>(
     writer: &mut W,
     int_coords: &mut [[i32;3]],

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -328,7 +328,6 @@ pub(crate) fn write_int_positions<W: Write>(
     Ok(compressed.len())
 }
 
-
 /// Encode coordinates with run-length compression and water swap.
 #[allow(clippy::too_many_arguments)]
 fn encode_coordinates(

--- a/tests/write.rs
+++ b/tests/write.rs
@@ -74,6 +74,87 @@ fn encode_size(path: &str) -> io::Result<usize> {
 }
 
 #[test]
+fn write_frame_parts_noncontiguous_ten() -> io::Result<()> {
+    let frames = XTCReader::open(trajectories::TEN)?.read_all_frames()?;
+    let atom_indices: &[usize] = &[1, 3, 7];
+
+    let mut buf = Vec::new();
+    {
+        let mut writer = XTCWriter::new(Cursor::new(&mut buf));
+        for frame in &frames {
+            let coords: Vec<[f32; 3]> = atom_indices
+                .iter()
+                .map(|&i| frame.positions[3 * i..3 * i + 3].try_into().unwrap())
+                .collect();
+            writer.write_frame_parts(frame.step, frame.time, frame.boxvec, coords.iter(), frame.precision)?;
+        }
+    }
+
+    let roundtrip = XTCReader::new(Cursor::new(&buf)).read_all_frames()?;
+
+    assert_eq!(frames.len(), roundtrip.len());
+    for (i, (orig, rt)) in frames.iter().zip(roundtrip.iter()).enumerate() {
+        assert_eq!(orig.step, rt.step, "frame {i}: step mismatch");
+        assert_eq!(orig.time, rt.time, "frame {i}: time mismatch");
+        assert_eq!(orig.boxvec, rt.boxvec, "frame {i}: boxvec mismatch");
+        assert_eq!(rt.positions.len(), atom_indices.len() * 3, "frame {i}: position count mismatch");
+        for (j, &atom_idx) in atom_indices.iter().enumerate() {
+            for k in 0..3 {
+                let orig_val = orig.positions[3 * atom_idx + k];
+                let rt_val = rt.positions[3 * j + k];
+                let diff = (orig_val - rt_val).abs();
+                assert!(
+                    diff < 1e-5,
+                    "frame {i}, atom {atom_idx}, coord {k}: mismatch ({orig_val} vs {rt_val}, diff {diff})"
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+#[test]
+fn write_frame_parts_noncontiguous_delinyah() -> io::Result<()> {
+    let frames = XTCReader::open(trajectories::DELINYAH)?.read_all_frames()?;
+    let natoms = frames[0].positions.len() / 3;
+    let atom_indices: Vec<usize> = (3..natoms).step_by(7).collect();
+
+    let mut buf = Vec::new();
+    {
+        let mut writer = XTCWriter::new(Cursor::new(&mut buf));
+        for frame in &frames {
+            let coords: Vec<[f32; 3]> = atom_indices
+                .iter()
+                .map(|&i| frame.positions[3 * i..3 * i + 3].try_into().unwrap())
+                .collect();
+            writer.write_frame_parts(frame.step, frame.time, frame.boxvec, coords.iter(), frame.precision)?;
+        }
+    }
+
+    let roundtrip = XTCReader::new(Cursor::new(&buf)).read_all_frames()?;
+
+    assert_eq!(frames.len(), roundtrip.len());
+    for (i, (orig, rt)) in frames.iter().zip(roundtrip.iter()).enumerate() {
+        assert_eq!(orig.step, rt.step, "frame {i}: step mismatch");
+        assert_eq!(orig.time, rt.time, "frame {i}: time mismatch");
+        assert_eq!(orig.boxvec, rt.boxvec, "frame {i}: boxvec mismatch");
+        assert_eq!(rt.positions.len(), atom_indices.len() * 3, "frame {i}: position count mismatch");
+        for (j, &atom_idx) in atom_indices.iter().enumerate() {
+            for k in 0..3 {
+                let orig_val = orig.positions[3 * atom_idx + k];
+                let rt_val = rt.positions[3 * j + k];
+                let diff = (orig_val - rt_val).abs();
+                assert!(
+                    diff < 1e-5,
+                    "frame {i}, atom {atom_idx}, coord {k}: mismatch ({orig_val} vs {rt_val}, diff {diff})"
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+#[test]
 #[ignore]
 fn report_compressed_sizes() -> io::Result<()> {
     let inputs = [


### PR DESCRIPTION
In practice one often wants to write a non-contiguous selection of atoms, so the coordinates come in a form of an arbitrary iterator, not a contiguous coordinate slice. In the current implementation of `write_frame()` one has to:

1. Collect an iterator into `Vec<f32>` and construct a `Frame` (first allocation).
2. Pass frame to `write_frame()`, which internally allocates a `Vec<[i32; 3]>` (second allocation).

However, step (1) is actually completely redundant - one may construct `Vec<[i32; 3]>` directly from the initial iterator saving one allocation (plus copying the coordinates) per frame.

This pull request introduces `write_frame_parts()` method which allows writing a frame given its "parts": step, time, precision, etc. and an iterator over coordinates.

Internally the only change is factoring out `write_int_positions()` to be used in both `write_frame_parts` and `write_frame`. No other changes required, all tests still pass.