### PR TITLE
Python binding improvements

### DIFF
--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -167,15 +167,13 @@ impl XTCReader {
 
     /// Read a single frame into the `frame` field of the `XTCReader`.
     fn read_frame(&mut self, py: Python) -> io::Result<()> {
-        let mut frame = self
-            .frame
-            .get_or_insert(Py::new(py, Frame::default())?)
-            .clone_ref(py);
-        self.inner()?.read_frame(&mut frame.borrow_mut(py).inner)?;
+        let mut frame = Frame::default();
+        self.inner()?.read_frame(&mut frame.inner)?;
+        self.frame = Some(Py::new(py, frame)?);
         Ok(())
     }
 
-    /// Read a single frame and return a copy.
+    /// Read a single frame and return it.
     ///
     /// Calls `read_frame` internally and returns the frame immediately.
     fn pop_frame(&mut self, py: Python) -> io::Result<Py<Frame>> {

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -92,7 +92,7 @@ impl FromPyObject<'_> for AtomSelection {
 struct XTCReader {
     // None if the reader was closed
     inner: Option<molly::XTCReader<std::fs::File>>,
-    // None before any frames were read
+    // None before any frames were read, or after all frames were read
     frame: Option<Py<Frame>>,
     buffered: bool,
 }
@@ -166,9 +166,19 @@ impl XTCReader {
     }
 
     /// Read a single frame into the `frame` field of the `XTCReader`.
+    ///
+    /// If all frames were already read, will set the `frame` field to None.
     fn read_frame(&mut self, py: Python) -> io::Result<()> {
         let mut frame = Frame::default();
-        self.inner()?.read_frame(&mut frame.inner)?;
+        if let Err(err) = self.inner()?.read_frame(&mut frame.inner) {
+            return match err.kind() {
+                io::ErrorKind::UnexpectedEof => {
+                    self.frame = None;
+                    Ok(())
+                }
+                _ => Err(err),
+            };
+        }
         self.frame = Some(Py::new(py, frame)?);
         Ok(())
     }
@@ -176,9 +186,11 @@ impl XTCReader {
     /// Read a single frame and return it.
     ///
     /// Calls `read_frame` internally and returns the frame immediately.
-    fn pop_frame(&mut self, py: Python) -> io::Result<Py<Frame>> {
+    ///
+    /// If all frames were already read, returns None.
+    fn pop_frame(&mut self, py: Python) -> io::Result<Option<Py<Frame>>> {
         self.read_frame(py)?;
-        Ok(self.frame.as_ref().unwrap().clone_ref(py))
+        Ok((&self.frame).as_ref().map(|x| x.clone_ref(py)))
     }
 
     /// Read frames according to the selections and return the frames as a list.

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -90,9 +90,21 @@ impl FromPyObject<'_> for AtomSelection {
 /// A fast XTC trajectory reader.
 #[pyclass]
 struct XTCReader {
-    inner: molly::XTCReader<std::fs::File>,
+    // None if the reader was closed
+    inner: Option<molly::XTCReader<std::fs::File>>,
+    // None before any frames were read
     frame: Option<Py<Frame>>,
     buffered: bool,
+}
+
+impl XTCReader {
+    /// Return a mutable reference to inner, or a Python exception if it is None.
+    fn inner(&mut self) -> io::Result<&mut molly::XTCReader<std::fs::File>> {
+        match &mut self.inner {
+            Some(inner) => Ok(inner),
+            None => Err(io::Error::new(io::ErrorKind::Other, "Reader is closed")),
+        }
+    }
 }
 
 #[pymethods]
@@ -103,7 +115,7 @@ impl XTCReader {
     fn open(path: PathBuf, buffered: bool) -> io::Result<Self> {
         let inner = molly::XTCReader::open(path)?;
         Ok(Self {
-            inner,
+            inner: Some(inner),
             frame: None,
             buffered,
         })
@@ -137,18 +149,20 @@ impl XTCReader {
     /// the initial reader position, call `XTCReader.home` before calling this function.
     #[pyo3(signature = (until=None))]
     fn determine_offsets(&mut self, until: Option<usize>) -> io::Result<Vec<u64>> {
-        self.inner.determine_offsets(until).map(|l| l.to_vec())
+        self.inner()?.determine_offsets(until).map(|l| l.to_vec())
     }
 
     /// Returns the frame sizes in bytes of this `XTCReader`.
     #[pyo3(signature = (until=None))]
     fn determine_frame_sizes(&mut self, until: Option<usize>) -> io::Result<Vec<u64>> {
-        self.inner.determine_frame_sizes(until).map(|l| l.to_vec())
+        self.inner()?
+            .determine_frame_sizes(until)
+            .map(|l| l.to_vec())
     }
 
     /// Reset the reading head to the start of the file.
     fn home(&mut self) -> PyResult<()> {
-        Ok(self.inner.home()?)
+        Ok(self.inner()?.home()?)
     }
 
     /// Read a single frame into the `frame` field of the `XTCReader`.
@@ -156,8 +170,9 @@ impl XTCReader {
         let mut frame = self
             .frame
             .get_or_insert(Py::new(py, Frame::default())?)
-            .borrow_mut(py);
-        self.inner.read_frame(&mut frame.inner)
+            .clone_ref(py);
+        self.inner()?.read_frame(&mut frame.borrow_mut(py).inner)?;
+        Ok(())
     }
 
     /// Read a single frame and return a copy.
@@ -185,13 +200,14 @@ impl XTCReader {
         let atom_selection = atom_selection.unwrap_or_default().into();
         match self.buffered {
             true => {
-                self.inner
+                self.inner()?
                     .read_frames::<true>(&mut frames, &frame_selection, &atom_selection)?
             }
-            false => {
-                self.inner
-                    .read_frames::<false>(&mut frames, &frame_selection, &atom_selection)?
-            }
+            false => self.inner()?.read_frames::<false>(
+                &mut frames,
+                &frame_selection,
+                &atom_selection,
+            )?,
         };
 
         Ok(frames.into_iter().map(|frame| frame.into()).collect())
@@ -276,7 +292,7 @@ impl XTCReader {
         let until = frame_selection
             .as_ref()
             .and_then(|FrameSelection(selection)| selection.until());
-        let offsets = self.inner.determine_offsets(until)?;
+        let offsets = self.inner()?.determine_offsets(until)?;
         let offsets = offsets.iter().enumerate().filter_map(|(idx, offset)| {
             if let Some(FrameSelection(selection)) = &frame_selection {
                 match selection.is_included(idx) {
@@ -298,11 +314,14 @@ impl XTCReader {
             py.check_signals()?;
             match self.buffered {
                 true => {
-                    self.inner
-                        .read_frame_at_offset::<true>(&mut frame, offset, &atom_selection)?;
+                    self.inner()?.read_frame_at_offset::<true>(
+                        &mut frame,
+                        offset,
+                        &atom_selection,
+                    )?;
                 }
                 false => {
-                    self.inner.read_frame_at_offset::<false>(
+                    self.inner()?.read_frame_at_offset::<false>(
                         &mut frame,
                         offset,
                         &atom_selection,
@@ -336,6 +355,11 @@ impl XTCReader {
         }
 
         Ok(true)
+    }
+
+    fn close(&mut self) -> io::Result<()> {
+        self.inner.take();
+        Ok(())
     }
 }
 

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -1,6 +1,7 @@
 #![allow(non_local_definitions, dead_code)]
 
 use std::io;
+use std::io::Seek;
 use std::num::NonZeroU64;
 use std::path::PathBuf;
 
@@ -193,6 +194,27 @@ impl XTCReader {
         Ok((&self.frame).as_ref().map(|x| x.clone_ref(py)))
     }
 
+    /// Skip a single frame and return the file position after.
+    ///
+    /// Returns None if no frame could be skipped.
+    fn skip_frame(&mut self) -> io::Result<Option<u64>> {
+        let header = match self.inner()?.read_header() {
+            Ok(x) => x,
+            Err(err) => {
+                return match err.kind() {
+                    io::ErrorKind::UnexpectedEof => Ok(None),
+                    _ => Err(err),
+                }
+            }
+        };
+        Ok(Some(self.inner()?.skip_positions(&header)?))
+    }
+
+    /// Get the current file position.
+    fn tell(&mut self) -> io::Result<u64> {
+        self.inner()?.file.stream_position()
+    }
+
     /// Read frames according to the selections and return the frames as a list.
     ///
     /// # Note
@@ -381,10 +403,20 @@ struct XTCWriter {
 
 #[pymethods]
 impl XTCWriter {
-    /// Create a new XTC file at the given path.
+    /// Open an XTC file at the given path for writing.
+    ///
+    /// If append is False (default), it will try to create a new file.
+    ///
+    /// If append is True, it will append to the existing file. In this case,
+    /// an exception will be raised if the file does not exist yet.
     #[new]
-    fn create(path: PathBuf) -> io::Result<Self> {
-        let file = std::fs::File::create(path)?;
+    #[pyo3(signature = (path, /, append=false))]
+    fn create(path: PathBuf, append: bool) -> io::Result<Self> {
+        let file = if append {
+            std::fs::OpenOptions::new().append(true).open(path)?
+        } else {
+            std::fs::File::create(path)?
+        };
         let writer = std::io::BufWriter::new(file);
         Ok(Self {
             inner: Some(molly::XTCWriter::new(writer)),

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -91,9 +91,9 @@ impl FromPyObject<'_> for AtomSelection {
 /// A fast XTC trajectory reader.
 #[pyclass]
 struct XTCReader {
-    // None if the reader was closed
+    // `None` if the reader was closed.
     inner: Option<molly::XTCReader<std::fs::File>>,
-    // None before any frames were read, or after all frames were read
+    // `None` before any frames were read, or after all frames were read.
     frame: Option<Py<Frame>>,
     buffered: bool,
 }

--- a/bindings/python/tests/verification.py
+++ b/bindings/python/tests/verification.py
@@ -232,6 +232,97 @@ def test_reference_semantics(path):
     print("\tXTCReader.frame has reference semantics")
 
 
+def test_append():
+    """Test appending to existing .xtc files."""
+    print("TEST: append")
+    # Write temp file.
+    with tempfile.NamedTemporaryFile(suffix=".xtc", delete=False) as tmp:
+        tmp_path = tmp.name
+    start = time.time()
+    writer = molly.XTCWriter(tmp_path)
+    generator = np.random.default_rng(seed=1234)
+    n_atoms = 1000
+    n_frames = 1000
+    append_every = 100
+
+    positions = generator.random((n_frames, n_atoms, 3), dtype=np.float32) * 5.
+    box = np.array([
+        [5., 0., 0.],
+        [0., 5., 0.],
+        [0., 0., 5.]
+    ], dtype=np.float32)
+    for i, frame in enumerate(positions):
+        f = molly.Frame()
+        f.box = box
+        f.positions = frame.flatten()
+        f.time = i * 0.02
+        f.step = i
+        # precision intentionally left blank
+        writer.write_frame(f)
+        if i > 0 and i % append_every == 0:
+            writer.close()
+            writer = molly.XTCWriter(tmp_path, append=True)
+    writer.close()
+    print(f"\tWrote {n_frames} frames {n_atoms} atoms in {time.time() - start:.3f} s")
+
+    # Read back and check if it's the same.
+    start = time.time()
+    reader = molly.XTCReader(tmp_path)
+    read_positions = np.empty((n_frames, n_atoms, 3), dtype=np.float32)
+    for i in range(n_frames):
+        read_positions[i, :, :] = reader.pop_frame().positions
+    assert reader.pop_frame() is None
+
+    for i in range(n_frames):
+        assert np.allclose(
+            positions[i],
+            read_positions[i],
+            rtol=0.,
+            atol=1e-3
+        ), f"Frame {i}: Coordinate mismatch."
+    print(f"\tRead {n_frames} frames {n_atoms} atoms in {time.time() - start:.3f} s")
+
+    # Clean up.
+    import os
+    os.unlink(tmp_path)
+
+    print(f"\tOK!\tAppend for {n_frames} frames.")
+
+
+def test_skipping_frames(path):
+    """Read some frames and verify them, then skip some frames."""
+
+    print("TEST: skip frames")
+    mda_reader, molly_reader = setup_readers(path)
+
+    for i in range(mda_reader.n_frames):
+        if i % 5 > 0:
+            molly_reader.skip_frame()
+        else:
+            mda_positions = mda_reader.trajectory[i].positions
+            molly_positions = molly_reader.pop_frame().positions
+            assert mda_positions.tolist() == molly_positions.tolist()
+    print(f"\tOK!\tSkip frames for {mda_reader.n_frames} frames.")
+
+def test_skip_and_tell(path):
+    """Compare the file positions given by tell() and skip_frame()."""
+
+    print("TEST: skip and tell")
+    offsets = []
+    reader = molly.XTCReader(path)
+
+    while (offset := reader.skip_frame()) is not None:
+        offsets.append(offset)
+    
+    reader.close()
+    reader = molly.XTCReader(path)
+    for offset in offsets:
+        reader.pop_frame()
+        assert offset == reader.tell()
+
+    reader.close()
+    print("\tOK!\tSkip and tell.")
+
 path = "../../tests/trajectories/trajectory_smol.xtc"
 full_mda_frames, _ = read_all(path)
 
@@ -254,3 +345,10 @@ test_write_from_scratch()
 
 # XTC Reader frame reference semantics
 test_reference_semantics(path)
+
+# Appending with XTC Writer
+test_append()
+
+# Test skip and tell
+test_skipping_frames(path)
+test_skip_and_tell(path)

--- a/bindings/python/tests/verification.py
+++ b/bindings/python/tests/verification.py
@@ -212,18 +212,22 @@ def test_reference_semantics(path):
     reader = molly.XTCReader(path)
     # read 1 frame
     f = reader.pop_frame()
+    # overwrite it through the reference
+    # first frame in this particular file is at MD step 0
     assert f.step == 0
+    f.step = 5
+    # reader.frame and anything returned by pop_frame() and read_frame()
+    # should be a reference
+    assert reader.frame.step == 5
     # read another frame
     reader.read_frame()
-    # checks whether f is a reference to a single buffered "frame" that
-    # can be mutated by the reader
-    assert f.step > 0
-    # mutate f manually and check if it updated reader.f
-    chosen_number = f.step + 0xabc
-    f.step = chosen_number
-    assert reader.frame.step == chosen_number
-    print(f"\tOK!")
-    print(f"\tXTCReader.frame has reference semantics")
+    # f should remain a frame containing the old positions
+    assert f.step == 5
+    f.step = 0
+    # reader.frame should be a new frame
+    assert reader.frame.step > 0
+    print("\tOK!")
+    print("\tXTCReader.frame has reference semantics")
 
 
 path = "../../tests/trajectories/trajectory_smol.xtc"

--- a/bindings/python/tests/verification.py
+++ b/bindings/python/tests/verification.py
@@ -43,6 +43,7 @@ def read_all(path):
         mda_frames.append(mda_positions.copy())
         molly_frames.append(molly_positions.copy())
 
+    molly_reader.close()
     return mda_frames, molly_frames
 
 

--- a/bindings/python/tests/verification.py
+++ b/bindings/python/tests/verification.py
@@ -43,6 +43,7 @@ def read_all(path):
         mda_frames.append(mda_positions.copy())
         molly_frames.append(molly_positions.copy())
 
+    assert molly_reader.pop_frame() is None
     molly_reader.close()
     return mda_frames, molly_frames
 
@@ -190,6 +191,7 @@ def test_write_from_scratch():
     read_positions = np.empty((n_frames, n_atoms, 3), dtype=np.float32)
     for i in range(n_frames):
         read_positions[i, :, :] = reader.pop_frame().positions
+    assert reader.pop_frame() is None
 
     for i in range(n_frames):
         assert np.allclose(


### PR DESCRIPTION
All changes are only to the python bindings. Commit times are recent because of a recent rebase.

1. XTCReader.inner type change T to Option<T>, which is set to None after close() is called. A function inner() is defined, which allows existing code to substitute .inner with .inner()? to raise exceptions in an ergonomic manner.

2. Semantic change that creates a new Frame (using Frame::default) every frame. 

Since reference semantics, reader.frame and reader.pop_frame() return references to Frames, and the repeated .clone() for each .frame access was removed for both when reading the frame out, resolving the //FIXME in the code.

However, since then I realized I did not think through the fact that if the user keeps track of references to old Frame instances, those will get updated when further frames are read. I apologize for this oversight.

The overall change since before the original PR about reference semantics is that instead of `reader.frame` access cloning, allocation happens on frame read once.

3. Modifies read_frame to set self.frame to None if EOF is reached. Likewise modifies pop_frame to not unwrap self.frame, but return None if it is None. Previously, EOF would raise an exception.

This is motivated by the following use case:

```py
r = molly.XTCReader(path)
frames = []
while (frame := r.pop_frame()) is not None:
    frames.append(frame)
```

I am not sure if this aligns with your vision for these functions. I have only checked mdtraj.formats.XTCReader for what it does, and that one returns empty frames after the file is over, rather than raise an exception.

4. Adds miscellaneous extra options to the python XTC Reader and Writer, which were already possible through the Rust API , but not the python bindings:

- `tell()` to return the current position in the file
- `skip_frame()` to skip a frame without decompressing positions, and returning the position in the file
- `append=False` optional keyword argument to XTCWriter, which if set to True will try to append to a pre-existing file, rather than truncate it when opening if it already exists.

These changes are motivated to support truncating to certain frame counts and then appending to XTC files without reading, decompressing and writing a new file.